### PR TITLE
2023.1 compatibility

### DIFF
--- a/FindAndLoadSettings.cs
+++ b/FindAndLoadSettings.cs
@@ -42,7 +42,7 @@ namespace ReshSettingsDiscover
 
                             // Physical storage
                             var fsSettingsfile = FileSystemPath.Parse(settingsfile.FullPath);
-                            IProperty<FileSystemPath> livepath = new Property<FileSystemPath>(lifetimeLocation, "StoragePath", fsSettingsfile);
+                            IProperty<FileSystemPath> livepath = new Property<FileSystemPath>("StoragePath", fsSettingsfile);
                             var storage = new XmlFileSettingsStorage(lifetimeLocation, name, livepath, SettingsStoreSerializationToXmlDiskFile.SavingEmptyContent.KeepFile, threading, filetracker, behavior, null);
 
                             // Mount as a layer

--- a/ReshSettingsDiscover.csproj
+++ b/ReshSettingsDiscover.csproj
@@ -9,8 +9,8 @@
       <None Remove="ReshSettingsDiscover.nuspec" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="JetBrains.Lifetimes" Version="2022.3.3" />
-      <PackageReference Include="JetBrains.ReSharper.SDK" Version="2022.3.0">
+      <PackageReference Include="JetBrains.Lifetimes" Version="2023.1.2" />
+      <PackageReference Include="JetBrains.ReSharper.SDK" Version="2023.1.3">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/ReshSettingsDiscover.nuspec
+++ b/ReshSettingsDiscover.nuspec
@@ -2,18 +2,18 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>ReshSettings.Discover</id>
-        <version>2.25</version>
+        <version>2.26</version>
         <title>ReSharper Solution Settings Autodiscovery</title>
         <authors>hypersw,awelburn</authors>
         <owners>hypersw,awelburn</owners>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>When you open a solution in Visual Studio, this plugin looks for any *.AutoLoad.DotSettings files in parent folders and loads them as ReSharper settings layers. This allows to apply a root settings file to all solutions in the same source control.</description>
-        <releaseNotes>ReSharper 2022.3 compatibility</releaseNotes>
+        <releaseNotes>ReSharper 2023.1 compatibility</releaseNotes>
         <tags>Settings</tags>
         <projectUrl>https://github.com/Artesian/reshsettingsdiscover</projectUrl>
         <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
         <dependencies>
-            <dependency id="Wave" version="[223.0.0]" />
+            <dependency id="Wave" version="[231.0.0]" />
         </dependencies>
     </metadata>
     <files>

--- a/ReshSettingsDiscover.nuspec
+++ b/ReshSettingsDiscover.nuspec
@@ -13,10 +13,10 @@
         <projectUrl>https://github.com/Artesian/reshsettingsdiscover</projectUrl>
         <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
         <dependencies>
-            <dependency id="Wave" version="[231.0.0]" />
+            <dependency id="Wave" version="231.0.0"/>
         </dependencies>
     </metadata>
     <files>
-    <file src="bin\Release\net472\ReshSettingsDiscover.dll" target="dotFiles" />
+        <file src="bin\Release\net472\ReshSettingsDiscover.dll" target="dotFiles"/>
     </files>
 </package>


### PR DESCRIPTION
I do see a warning:
```
reshsettingsdiscover\FindAndLoadSettings.cs(45,66,45,143): warning CS0618: 'Property<FileSystemPath>.Property(Lifetime, string, FileSystemPath)' is obsolete: 'Use overloads without lifetime.'
```

so that might need addressing before merging this?